### PR TITLE
Fix Claude add-on startup robustness

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -64,7 +64,8 @@ jobs:
     strategy:
       matrix:
         addon: ${{ fromJson(needs.init.outputs.changed_addons) }}
-        arch: ["aarch64", "amd64", "armhf", "armv7"] # "i386"
+        # Keep CI build coverage focused on Raspberry Pi 64-bit only.
+        arch: ["aarch64"]
     permissions:
       contents: read
       packages: write

--- a/claude-code/CHANGELOG.md
+++ b/claude-code/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v1.10.14 - Harden Telegram, MCP first boot, resume guards, and docs
+- Preconfigure the Telegram channel deterministically when `TELEGRAM_BOT_TOKEN`
+  is set: write the plugin `.env`, enable `telegram@claude-plugins-official`
+  in user settings, pass Telegram env vars into tmux, and pre-allowlist
+  `TELEGRAM_CHAT_ID` when supplied.
+- Move `claude mcp add homeassistant ...` after the Claude Code install/update
+  block so fresh data dirs with copied credentials register HA MCP on the first
+  valid boot.
+- Derive the Claude session project path from `WORK_DIR` instead of assuming
+  `/share/claude-workspace`.
+- Replace every-boot recursive `/data/claude` chmod with a one-time migration
+  marker to reduce startup time and SD-card write churn.
+- Update docs/translations to match current Telegram setup and the actual
+  remote-control URL/state paths.
+
 ## v1.10.13 - Fix HA MCP registration: use `claude mcp add` instead of settings.json
 - MCP servers are stored in `$HOME/.claude.json`, not `settings.json`. Writing
   to settings.json (v1.10.10–v1.10.12) had no effect.

--- a/claude-code/DOCS.md
+++ b/claude-code/DOCS.md
@@ -12,11 +12,14 @@ Before starting, fill in the add-on configuration:
 
 | Option | Required | Default | Description |
 |---|---|---|---|
-| `TELEGRAM_BOT_TOKEN` | No | — | Bot token from [@BotFather](https://t.me/BotFather). Enables Telegram integration. |
+| `TELEGRAM_BOT_TOKEN` | No | — | Bot token from [@BotFather](https://t.me/BotFather). Enables Telegram channel startup and direct startup DMs. |
+| `TELEGRAM_CHAT_ID` | No | — | Your numeric Telegram user/chat ID. When set, the add-on sends startup DMs and pre-allowlists that ID for Telegram input. |
 | `WORK_DIR` | No | `/share/claude-workspace` | Directory where Claude Code runs and stores files. |
 | `AUTO_UPDATE_CHECK` | No | `true` | Check for Claude Code updates on each startup. Only downloads if a newer version is available. |
+| `DAEMON_AUTOSTART` | No | `true` | Set false to keep only the Web UI terminal running for manual setup or debugging. |
+| `HA_TOKEN` | No | — | Long-Lived Access Token fallback for Home Assistant API access if the supervisor token is unavailable. |
 
-If you want Telegram, create a bot with [@BotFather](https://t.me/BotFather) now and copy the token into `TELEGRAM_BOT_TOKEN` before proceeding.
+If you want Telegram, create a bot with [@BotFather](https://t.me/BotFather) now and copy the token into `TELEGRAM_BOT_TOKEN`. For the smoothest first boot, also set `TELEGRAM_CHAT_ID` to your numeric Telegram user ID from [@userinfobot](https://t.me/userinfobot).
 
 ### Step 2 — Authenticate with your Claude.ai account
 
@@ -35,11 +38,12 @@ Go back to the add-on page and click **Restart**.
 
 On this restart, the add-on will automatically:
 1. Detect that you are now authenticated.
-2. If `TELEGRAM_BOT_TOKEN` is set — run the full Telegram plugin setup:
-   - Install the official Anthropic plugin marketplace
-   - Install the Telegram channel plugin
-   - Configure the bot token
-3. Start Claude Code with the Telegram channel active (`--channels plugin:telegram@claude-plugins-official`).
+2. Ensure the Home Assistant MCP server is registered for Claude Code.
+3. If `TELEGRAM_BOT_TOKEN` is set:
+   - Write the bot token to `/data/claude/.claude/channels/telegram/.env`
+   - Enable `telegram@claude-plugins-official` in Claude Code user settings
+   - If `TELEGRAM_CHAT_ID` is set, write it to the Telegram allowlist
+   - Start Claude Code with `--channels plugin:telegram@claude-plugins-official`
 
 > **That's it.** Claude Code is now running. You do not need to touch the terminal again unless something goes wrong.
 
@@ -47,11 +51,19 @@ On this restart, the add-on will automatically:
 
 ## Telegram — Pairing your account
 
-After the restart, Claude Code starts polling Telegram for messages, but it won't respond to anyone until you pair your account:
+After the restart, Claude Code starts polling Telegram for messages.
+
+If `TELEGRAM_CHAT_ID` is set, the add-on pre-allowlists that ID and your DM should reach Claude directly.
+
+If `TELEGRAM_CHAT_ID` is not set, use the plugin's pairing flow:
 
 1. Open Telegram and DM your bot (e.g. `/start`).
 2. The bot replies with a **pairing code**.
-3. Open the **Web UI terminal** and approve the pairing — type `yes` when prompted.
+3. Open the **Web UI terminal**, run `claude-attach`, then type these in Claude Code:
+   ```
+   /telegram:access pair <code>
+   /telegram:access policy allowlist
+   ```
 
 After pairing, you can send prompts to Claude Code directly from Telegram and receive responses.
 
@@ -65,7 +77,7 @@ When Claude Code starts, it registers a remote control session reachable from an
 
 The session URL is automatically:
 - Printed in the **add-on log** (Supervisor → Claude Code → Log)
-- Saved to `/data/remote_control_url.txt` (readable from the Web UI terminal: `cat /data/remote_control_url.txt`)
+- Saved to `/data/claude/remote_control_url.txt` (readable from the Web UI terminal: `cat /data/claude/remote_control_url.txt`)
 - Shown as a **persistent notification** in your Home Assistant dashboard
 
 Open the URL in any browser or the Claude mobile app to control the running session remotely.
@@ -77,8 +89,8 @@ Open the URL in any browser or the Claude mobile app to control the running sess
 Claude Code always starts with `--continue` to resume the previous session.
 
 A `CLAUDE.md` file is automatically created in your workspace on first run. It instructs Claude to:
-- Read `memory.md` at the start of every session to restore context
-- Update `memory.md` at the end of each session with tasks, preferences, and discoveries
+- Read `MEMORY.md` at the start of every session to restore context
+- Update `MEMORY.md` at the end of each session with tasks, preferences, and discoveries
 - Mention remembered context proactively when relevant
 
 This gives Claude persistent memory across restarts without any manual effort.
@@ -87,7 +99,7 @@ This gives Claude persistent memory across restarts without any manual effort.
 
 ## Updates
 
-When `AUTO_UPDATE_CHECK` is enabled (default), the add-on checks npm for a newer `@anthropic-ai/claude-code` version on every startup. If a new version is found, it downloads and installs it once — the binary lives in `/data/npm-global` (persistent storage) and is reused on subsequent restarts.
+When `AUTO_UPDATE_CHECK` is enabled (default), the add-on checks npm for a newer `@anthropic-ai/claude-code` version on every startup. If a new version is found, it downloads and installs it once — the binary lives in `/data/claude/npm-global` (persistent storage) and is reused on subsequent restarts.
 
 **To force a manual update:** disable `AUTO_UPDATE_CHECK`, restart, re-enable it, restart again.
 
@@ -100,7 +112,7 @@ The **Open Web UI** button opens a full bash terminal in your browser (via ttyd)
 - Approve Telegram pairing codes
 - Inspect workspace files
 - Run `claude` interactively for debugging
-- Check `cat /data/remote_control_url.txt` for the latest remote control URL
+- Check `cat /data/claude/remote_control_url.txt` for the latest remote control URL
 
 ---
 
@@ -114,4 +126,4 @@ scp ~/.claude/.credentials.json \
   root@homeassistant.local:/data/addon_data/local_claude-code/claude/.claude/
 ```
 
-Then restart the add-on — it will detect the credentials and proceed directly to Telegram setup.
+Then restart the add-on — it will detect the credentials and proceed directly to the daemon startup.

--- a/claude-code/README.md
+++ b/claude-code/README.md
@@ -9,7 +9,7 @@ Run [Claude Code](https://claude.ai/code) as a persistent AI agent on your Home 
 - **Remote control** — access your session from anywhere via claude.ai/code
 - **Web terminal** — browser-based terminal for login and interactive use
 - **Smart updates** — automatically installs new Claude Code versions without rebuilding the image
-- **Memory** — maintains context across restarts via `memory.md`
+- **Memory** — maintains context across restarts via `MEMORY.md`
 
 ## Requirements
 

--- a/claude-code/config.yaml
+++ b/claude-code/config.yaml
@@ -1,6 +1,6 @@
 # https://developers.home-assistant.io/docs/add-ons/configuration#add-on-config
 name: Claude Code
-version: "v1.10.13"
+version: "v1.10.14"
 slug: claude-code
 description: "Run Claude Code as a persistent AI agent with Telegram and remote control"
 url: "https://github.com/zutlik/ha-addons/tree/main/claude-code"

--- a/claude-code/run.sh
+++ b/claude-code/run.sh
@@ -18,9 +18,17 @@ CLAUDE_HOME="/data/claude"
 # ============================================================
 mkdir -p "$CLAUDE_HOME"
 chmod 777 "$CLAUDE_HOME"
-# Legacy boots created subtrees as root; without CAP_CHOWN we can't chown,
-# so make everything under /data/claude writable by the claude user.
-chmod -R a+rwX "$CLAUDE_HOME" 2>/dev/null || true
+# Legacy boots created subtrees as root; without relying on chown, make the
+# existing tree writable once, then keep future boots cheap for SD-card installs.
+_PERMS_MARKER="$CLAUDE_HOME/.permissions_migrated_v1"
+if [ ! -e "$_PERMS_MARKER" ]; then
+    echo "[claude-code] Running one-time permissions migration for $CLAUDE_HOME..."
+    chmod -R a+rwX "$CLAUDE_HOME" 2>/dev/null || true
+    printf '%s\n' "$(date -Iseconds 2>/dev/null || date)" > "$_PERMS_MARKER" 2>/dev/null || true
+    chmod 666 "$_PERMS_MARKER" 2>/dev/null || true
+else
+    chmod a+rwX "$CLAUDE_HOME" "$CLAUDE_HOME/.claude" "$CLAUDE_HOME/.npm" "$CLAUDE_HOME/npm-global" 2>/dev/null || true
+fi
 
 # ============================================================
 # HA token + URL selection
@@ -112,10 +120,12 @@ DAEMON_AUTOSTART=$(get_option "DAEMON_AUTOSTART" "true")
 # The plugin stores its token in ~/.claude/channels/telegram/.env and the
 # allowed chat IDs in access.json — use those so startup pings work even
 # when the addon options are left blank.
-PLUGIN_ENV="$CLAUDE_HOME/.claude/channels/telegram/.env"
-ACCESS_JSON="$CLAUDE_HOME/.claude/channels/telegram/access.json"
+CLAUDE_SETTINGS="$CLAUDE_HOME/.claude/settings.json"
+TELEGRAM_PLUGIN_DIR="$CLAUDE_HOME/.claude/channels/telegram"
+PLUGIN_ENV="$TELEGRAM_PLUGIN_DIR/.env"
+ACCESS_JSON="$TELEGRAM_PLUGIN_DIR/access.json"
 if [ -z "$TELEGRAM_TOKEN" ] && [ -f "$PLUGIN_ENV" ]; then
-    TELEGRAM_TOKEN=$(grep -oP '(?<=TELEGRAM_BOT_TOKEN=).+' "$PLUGIN_ENV" | head -1)
+    TELEGRAM_TOKEN=$(sed -n 's/^TELEGRAM_BOT_TOKEN=//p' "$PLUGIN_ENV" | head -1)
     echo "[claude-code] Telegram: token loaded from plugin .env"
 fi
 if [ -z "$TELEGRAM_CHAT_ID" ] && [ -f "$ACCESS_JSON" ]; then
@@ -123,8 +133,88 @@ if [ -z "$TELEGRAM_CHAT_ID" ] && [ -f "$ACCESS_JSON" ]; then
     [ -n "$TELEGRAM_CHAT_ID" ] && echo "[claude-code] Telegram: chat_id ${TELEGRAM_CHAT_ID} loaded from access.json"
 fi
 
+merge_json_file() {
+    local file="$1" patch="$2" label="$3"
+    mkdir -p "$(dirname "$file")"
+    chmod a+rwX "$(dirname "$file")" 2>/dev/null || true
+    [ ! -f "$file" ] && printf '{}\n' > "$file"
+    chmod 666 "$file" 2>/dev/null || true
+
+    if MERGED=$(jq --argjson patch "$patch" '. * $patch' "$file" 2>/dev/null); then
+        printf '%s\n' "$MERGED" > "$file"
+    else
+        printf '%s\n' "$patch" > "$file"
+        echo "[claude-code] WARNING: replaced malformed $label with a fresh JSON file."
+    fi
+    chmod 666 "$file" 2>/dev/null || true
+}
+
+configure_telegram_channel() {
+    [ -n "$TELEGRAM_TOKEN" ] || return 0
+
+    mkdir -p "$TELEGRAM_PLUGIN_DIR"
+    chmod a+rwX "$CLAUDE_HOME/.claude" "$CLAUDE_HOME/.claude/channels" "$TELEGRAM_PLUGIN_DIR" 2>/dev/null || true
+    chmod 666 "$PLUGIN_ENV" 2>/dev/null || true
+    printf 'TELEGRAM_BOT_TOKEN=%s\n' "$TELEGRAM_TOKEN" \
+        | su -s /bin/bash claude -c "
+            set -e
+            umask 077
+            mkdir -p '$TELEGRAM_PLUGIN_DIR'
+            cat > '$PLUGIN_ENV'
+            chmod 600 '$PLUGIN_ENV' 2>/dev/null || true
+        " \
+        && echo "[claude-code] Telegram: bot token written to plugin .env." \
+        || echo "[claude-code] WARNING: failed to write Telegram plugin .env."
+
+    TELEGRAM_SETTINGS_PATCH=$(cat <<'JSON'
+{
+  "enabledPlugins": {
+    "telegram@claude-plugins-official": true
+  },
+  "extraKnownMarketplaces": {
+    "claude-plugins-official": {
+      "source": {
+        "source": "github",
+        "repo": "anthropics/claude-plugins-official"
+      }
+    }
+  }
+}
+JSON
+)
+    merge_json_file "$CLAUDE_SETTINGS" "$TELEGRAM_SETTINGS_PATCH" "Claude Code user settings"
+    echo "[claude-code] Telegram: official channel plugin enabled in user settings."
+
+    [ -f "$ACCESS_JSON" ] && chmod 666 "$ACCESS_JSON" 2>/dev/null || true
+    if [ -n "$TELEGRAM_CHAT_ID" ]; then
+        mkdir -p "$TELEGRAM_PLUGIN_DIR"
+        chmod a+rwX "$TELEGRAM_PLUGIN_DIR" 2>/dev/null || true
+        [ ! -f "$ACCESS_JSON" ] && printf '{}\n' > "$ACCESS_JSON"
+        chmod 666 "$ACCESS_JSON" 2>/dev/null || true
+        if UPDATED_ACCESS=$(jq --arg id "$TELEGRAM_CHAT_ID" '
+            .dmPolicy = (if (.dmPolicy // "pairing") == "disabled" then "disabled" else "allowlist" end)
+            | .allowFrom = (((.allowFrom // []) + [$id]) | unique)
+            | .groups = (.groups // {})
+            | .pending = (.pending // {})
+        ' "$ACCESS_JSON" 2>/dev/null); then
+            printf '%s\n' "$UPDATED_ACCESS" > "$ACCESS_JSON"
+        else
+            jq -n --arg id "$TELEGRAM_CHAT_ID" \
+                '{dmPolicy:"allowlist", allowFrom:[$id], groups:{}, pending:{}}' > "$ACCESS_JSON"
+            echo "[claude-code] WARNING: replaced malformed Telegram access.json with a fresh allowlist."
+        fi
+        chmod 666 "$ACCESS_JSON" 2>/dev/null || true
+        echo "[claude-code] Telegram: chat ${TELEGRAM_CHAT_ID} is allowlisted for inbound messages."
+    elif [ ! -f "$ACCESS_JSON" ]; then
+        printf '{"dmPolicy":"pairing","allowFrom":[],"groups":{},"pending":{}}\n' > "$ACCESS_JSON"
+        chmod 666 "$ACCESS_JSON" 2>/dev/null || true
+        echo "[claude-code] Telegram: no chat_id set; first DM will use the pairing-code flow."
+    fi
+}
+
 mkdir -p "$WORK_DIR"
 chmod 777 "$WORK_DIR" 2>/dev/null || true
+configure_telegram_channel
 
 # ============================================================
 # Telegram config diagnostics + startup ping. Fires independently of URL
@@ -215,38 +305,6 @@ else
 fi
 
 # ============================================================
-# Configure HA MCP server via `claude mcp add`.
-#
-# Claude Code stores MCP server config in $HOME/.claude.json (not settings.json).
-# The only reliable way to register a server is `claude mcp add`, which writes
-# to that file in the correct format.
-#
-# We run this as the claude user (HOME=$CLAUDE_HOME) so the write lands in the
-# right .claude.json. The --scope user flag stores it persistently; re-running
-# `claude mcp add` on an existing name overwrites it, so the token stays current
-# after rotation without any extra cleanup.
-#
-# The MCP endpoint is always http://homeassistant:8123/mcp_server/sse —
-# independent of HA_URL above (the supervisor proxy does not expose /mcp_server).
-# ============================================================
-_MCP_TOKEN=$(cat "$_TOKEN_FILE" 2>/dev/null || echo '')
-
-if [ -n "$_MCP_TOKEN" ]; then
-    su -s /bin/bash claude -c "
-        export HOME=$CLAUDE_HOME
-        export NPM_GLOBAL=$CLAUDE_HOME/npm-global
-        export PATH=\$NPM_GLOBAL/bin:/root/.bun/bin:\$PATH
-        claude mcp add homeassistant 'http://homeassistant:8123/mcp_server/sse' \
-            -t sse -s user \
-            -H 'Authorization: Bearer $_MCP_TOKEN' \
-            2>&1
-    " && echo "[claude-code] HA MCP server registered via claude mcp add." \
-      || echo "[claude-code] WARNING: claude mcp add failed — HA MCP server not registered."
-else
-    echo "[claude-code] WARNING: no HA token available — skipping MCP server config."
-fi
-
-# ============================================================
 # Run setup as the claude user so all files under /data/claude/
 # are created with claude ownership (no chown needed).
 # ============================================================
@@ -283,6 +341,40 @@ su -s /bin/bash claude -c "
 "
 
 # ============================================================
+# Configure HA MCP server via `claude mcp add`.
+#
+# Claude Code stores MCP server config in $HOME/.claude.json (not settings.json).
+# The only reliable way to register a server is `claude mcp add`, which writes
+# to that file in the correct format.
+#
+# This must run after the install/update block above. On a fresh data dir with
+# copied credentials, `claude` may not exist until npm install completes.
+#
+# The MCP endpoint is always http://homeassistant:8123/mcp_server/sse —
+# independent of HA_URL above (the supervisor proxy does not expose /mcp_server).
+# ============================================================
+_MCP_TOKEN=$(cat "$_TOKEN_FILE" 2>/dev/null || echo '')
+
+if [ -n "$_MCP_TOKEN" ]; then
+    su -s /bin/bash claude -c "
+        export HOME=$CLAUDE_HOME
+        export NPM_GLOBAL=$CLAUDE_HOME/npm-global
+        export PATH=\$NPM_GLOBAL/bin:/root/.bun/bin:\$PATH
+        if ! command -v claude >/dev/null 2>&1; then
+            echo '[claude-code] claude command unavailable after setup.'
+            exit 127
+        fi
+        claude mcp add homeassistant 'http://homeassistant:8123/mcp_server/sse' \
+            -t sse -s user \
+            -H 'Authorization: Bearer $_MCP_TOKEN' \
+            2>&1
+    " && echo "[claude-code] HA MCP server registered via claude mcp add." \
+      || echo "[claude-code] WARNING: claude mcp add failed — HA MCP server not registered."
+else
+    echo "[claude-code] WARNING: no HA token available — skipping MCP server config."
+fi
+
+# ============================================================
 # Start ttyd web terminal
 # ============================================================
 INGRESS_ENTRY="${INGRESS_PATH:-}"
@@ -309,12 +401,11 @@ if [ ! -f "$CLAUDE_HOME/.claude/.credentials.json" ]; then
 fi
 
 # ============================================================
-# DAEMON_AUTOSTART=false → manual-setup mode: skip Telegram setup AND
-# the claude daemon launch, keep only ttyd running. Use this to open
-# the Web UI and manually run `claude --dangerously-skip-permissions`
-# to accept one-time TUI prompts (trust dialog, bypass-permissions
-# warning). After prompts are accepted and claude has persisted them,
-# flip DAEMON_AUTOSTART back to true.
+# DAEMON_AUTOSTART=false → manual-setup mode: keep only ttyd running. Use
+# this to open the Web UI and manually run `claude --dangerously-skip-permissions`
+# to accept one-time TUI prompts (trust dialog, bypass-permissions warning) or
+# inspect channel/plugin state. After prompts are accepted and claude has
+# persisted them, flip DAEMON_AUTOSTART back to true.
 # ============================================================
 if [ "$DAEMON_AUTOSTART" != "true" ]; then
     echo "[claude-code] ============================================================"
@@ -352,6 +443,7 @@ echo "[claude-code] Remote control URL will appear in the logs and as an HA noti
 # accept prompts, type messages, watch it work — then detach with Ctrl-b d.
 # tmux also provides the PTY that claude needs to stay in interactive mode.
 TMUX_SESSION=claude
+CLAUDE_PROJECT_DIR="$CLAUDE_HOME/.claude/projects/$(printf '%s' "$WORK_DIR" | sed 's#/#-#g')"
 
 TRY_CONTINUE=yes
 while true; do
@@ -363,7 +455,7 @@ while true; do
     # internally. The fast-exit fallback below (< 15s) catches any other resume
     # failures without needing a pre-emptive size gate.
     if [ "$TRY_CONTINUE" = "yes" ]; then
-        RECENT_SESSION=$(ls -t "$CLAUDE_HOME/.claude/projects/-share-claude-workspace/"*.jsonl 2>/dev/null | head -1)
+        RECENT_SESSION=$(ls -t "$CLAUDE_PROJECT_DIR"/*.jsonl 2>/dev/null | head -1)
         if [ -n "$RECENT_SESSION" ]; then
             # Check if the last non-empty line contains a tool_use with no following
             # tool_result — sign of an in-flight tool call cut short by unclean exit.
@@ -427,10 +519,16 @@ print('pending' if last_tool_use else 'clean')
         export NO_COLOR=1
         STOKEN=\$(cat $CLAUDE_HOME/.supervisor_token 2>/dev/null || echo '')
         HA_URL_VAL=\$(cat $CLAUDE_HOME/.ha_url 2>/dev/null || echo 'http://supervisor/core')
+        TELEGRAM_TOKEN_VAL=\$(sed -n 's/^TELEGRAM_BOT_TOKEN=//p' '$PLUGIN_ENV' 2>/dev/null | head -1)
+        TELEGRAM_ENV_ARGS=''
+        if [ -n \"\$TELEGRAM_TOKEN_VAL\" ]; then
+            TELEGRAM_ENV_ARGS=\"-e TELEGRAM_BOT_TOKEN=\$TELEGRAM_TOKEN_VAL -e TELEGRAM_STATE_DIR=$TELEGRAM_PLUGIN_DIR\"
+        fi
         tmux kill-session -t $TMUX_SESSION 2>/dev/null || true
         cd '$WORK_DIR' && tmux new-session -d -s $TMUX_SESSION -x 200 -y 50 \
             -e SUPERVISOR_TOKEN=\"\$STOKEN\" \
             -e HA_URL=\"\$HA_URL_VAL\" \
+            \$TELEGRAM_ENV_ARGS \
             \"claude --model claude-sonnet-4-6 $CONTINUE_FLAG --dangerously-skip-permissions --remote-control $CHANNELS_ARG\"
     "
 

--- a/claude-code/translations/en.yaml
+++ b/claude-code/translations/en.yaml
@@ -4,6 +4,11 @@ configuration:
     description: >-
       Bot token from @BotFather. Enables Claude Code to receive prompts and
       send responses via Telegram. Leave empty to disable Telegram.
+  TELEGRAM_CHAT_ID:
+    name: Telegram Chat ID
+    description: >-
+      Numeric Telegram user/chat ID to notify and pre-allowlist for inbound
+      Telegram messages. Get it from @userinfobot.
   WORK_DIR:
     name: Work Directory
     description: >-
@@ -15,3 +20,13 @@ configuration:
       Check for a newer Claude Code version on each startup.
       Only downloads if a newer version is available; the binary is cached
       in persistent storage so subsequent restarts are fast.
+  DAEMON_AUTOSTART:
+    name: Daemon Autostart
+    description: >-
+      Start the persistent Claude Code daemon automatically. Disable temporarily
+      to use only the Web UI terminal for manual setup or debugging.
+  HA_TOKEN:
+    name: Home Assistant Token
+    description: >-
+      Optional Long-Lived Access Token fallback for Home Assistant API access
+      when the Supervisor token is unavailable or cannot reach HA Core.

--- a/publish-scripts/config.yaml
+++ b/publish-scripts/config.yaml
@@ -18,7 +18,6 @@ options:
 schema:
   NGROK_AUTH_TOKEN: "str"
   PORT: "int"
-restart_policy: unless-stopped
 image: "m3nadav/publish-scripts"
 homeassistant_api: true
 ingress: true

--- a/publish-scripts/config.yaml
+++ b/publish-scripts/config.yaml
@@ -21,7 +21,6 @@ schema:
 image: "m3nadav/publish-scripts"
 homeassistant_api: true
 ingress: true
-ingress_port: 8099
 panel_icon: mdi:script-text
 panel_title: "Publish Scripts"
 panel_admin: false

--- a/vision-addon/CHANGELOG.md
+++ b/vision-addon/CHANGELOG.md
@@ -13,10 +13,8 @@
 - Removed the supervisor token path. `homeassistant_api: true` is no longer
   needed; all HA API access flows through the LLAT against
   `http://homeassistant:8123`.
-- Startup hardening: 60-second timeout per attempt; supervisor restarts on
-  failure; capped at 3 consecutive failures via a counter file in `/data`.
-- `restart_policy` changed from `unless-stopped` to `on-failure` so the
-  retry cap actually takes effect.
+- Startup hardening: 60-second timeout per attempt; capped at 3 consecutive
+  failures via a counter file in `/data`.
 
 ## 1.1.8
 

--- a/vision-addon/config.yaml
+++ b/vision-addon/config.yaml
@@ -67,7 +67,6 @@ schema:
   camera_height: "int"
   processing_width: "int"
   jpeg_quality: "int"
-restart_policy: on-failure
 ingress: true
 ingress_port: 8080
 panel_icon: mdi:camera-account

--- a/vision-addon/run.sh
+++ b/vision-addon/run.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # Wrapper that runs the vision addon entrypoint with a startup-retry guard.
 #
-# HA Supervisor doesn't support `restart_policy: on-failure:max_retries`, so
-# we enforce a 3-attempt cap ourselves via a counter file in /data. The
+# HA Supervisor add-on config does not accept restart_policy, so we enforce a
+# 3-attempt startup cap ourselves via a counter file in /data. The
 # Python entrypoint resets the counter to 0 once it captures its first frame
 # (i.e. the camera came up). After 3 consecutive startup failures, we exit
 # cleanly so the supervisor stops restarting; the counter is reset at that


### PR DESCRIPTION
## Summary
- preconfigure Telegram channel state, token env, and access allowlist when add-on options are set
- move HA MCP registration after Claude Code install/update so fresh data dirs work on first valid boot
- derive resume-session path from WORK_DIR and replace recursive chmod with a one-time migration marker
- update docs, translations, README, changelog, and version to v1.10.14

## Validation
- bash -n claude-code/run.sh claude-code/claude-shell.sh claude-code/claude-attach.sh
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "OK #{f}" }' claude-code/config.yaml claude-code/build.yaml claude-code/translations/en.yaml
- git diff --check

Notes: shellcheck is not installed in this environment.